### PR TITLE
Fix issues with All selector generation

### DIFF
--- a/Fss.Core/Types/Html.fs
+++ b/Fss.Core/Types/Html.fs
@@ -112,3 +112,8 @@ namespace Fss.Types
             | Var
             | Video
             | Wbr
+            with
+            member this.Stringify () =
+                match this with
+                | All -> "*"
+                | _ -> this.ToString().ToLower()

--- a/Fss.Core/Types/MasterTypes.fs
+++ b/Fss.Core/Types/MasterTypes.fs
@@ -480,10 +480,10 @@ module Property =
                 | NthLastChild n -> $"nth-last-child({n})"
                 | NthOfType n -> $"nth-of-type({n})"
                 | NthLastOfType n -> $"nth-last-of-type({n})"
-                | AdjacentSibling html -> $" + {html.ToString().ToLower()}"
-                | GeneralSibling html -> $" ~ {html.ToString().ToLower()}"
-                | Child html -> $" > {html.ToString().ToLower()}"
-                | Descendant html -> $" {html.ToString().ToLower()}"
+                | AdjacentSibling html -> $" + {html.Stringify()}"
+                | GeneralSibling html -> $" ~ {html.Stringify()}"
+                | Child html -> $" > {html.Stringify()}"
+                | Descendant html -> $" {html.Stringify()}"
                 | Custom c -> c.ToLower()
                 | _ -> Fss.Utilities.Helpers.toKebabCase this
 

--- a/tests/Selector.fs
+++ b/tests/Selector.fs
@@ -20,72 +20,72 @@ module SelectorTests =
                testEqual
                    "Adjacent sibling"
                    actual
-                   $".{className} + all {{ color: blue; }}"
+                   $".{className} + * {{ color: blue; }}"
                let className, actual = createSelector [ Color.red; !+ Fss.Types.Html.All [ Color.blue ]; BackgroundColor.orangeRed ]
                testEqual
                    "Adjacent sibling"
                    actual
-                   $".{className} + all {{ color: blue; }}"
+                   $".{className} + * {{ color: blue; }}"
                    
                let className, actual = createSelector [ !~ Fss.Types.Html.All [ Color.blue ] ]
                testEqual
                    "General sibling"
                    actual
-                   $".{className} ~ all {{ color: blue; }}"
+                   $".{className} ~ * {{ color: blue; }}"
                let className, actual = createSelector [ Color.red; !~ Fss.Types.Html.All [ Color.blue ]; BackgroundColor.orangeRed ]
                testEqual
                    "General sibling"
                    actual
-                   $".{className} ~ all {{ color: blue; }}"
+                   $".{className} ~ * {{ color: blue; }}"
                    
                let className, actual = createSelector [ !> Fss.Types.Html.All [ Color.blue ] ]
                testEqual
                    "Child"
                    actual
-                   $".{className} > all {{ color: blue; }}"
+                   $".{className} > * {{ color: blue; }}"
                let className, actual = createSelector [ Color.red; !> Fss.Types.Html.All [ Color.blue ]; BackgroundColor.orangeRed ]
                testEqual
                    "Child"
                    actual
-                   $".{className} > all {{ color: blue; }}"
+                   $".{className} > * {{ color: blue; }}"
                    
                let className, actual = createSelector [ !  Fss.Types.Html.All [ Color.blue ] ]
                testEqual
                    "Descendant"
                    actual
-                   $".{className} all {{ color: blue; }}"
+                   $".{className} * {{ color: blue; }}"
                let className, actual = createSelector [ Color.red; !  Fss.Types.Html.All [ Color.blue ]; BackgroundColor.orangeRed ]
                testEqual
                    "Descendant" 
                    actual
-                   $".{className} all {{ color: blue; }}"
+                   $".{className} * {{ color: blue; }}"
                    
                let className, actual = createSelector [ Color.red; !+ Fss.Types.Html.All [ Hover [ BackgroundColor.aqua ] ]; BackgroundColor.orangeRed ]
                testEqual
                    "Adjacent sibling with pseudo" 
                    actual
-                   $".{className} + all:hover {{ background-color: aqua; }}"
+                   $".{className} + *:hover {{ background-color: aqua; }}"
                let className, actual = createSelector [ Color.red; !~ Fss.Types.Html.All [ Hover [ BackgroundColor.aqua ] ]; BackgroundColor.orangeRed ]
                testEqual
                    "General sibling with pseudo" 
                    actual
-                   $".{className} ~ all:hover {{ background-color: aqua; }}"
+                   $".{className} ~ *:hover {{ background-color: aqua; }}"
                let className, actual = createSelector [ Color.red; !>  Fss.Types.Html.All [ Hover [ BackgroundColor.aqua ] ]; BackgroundColor.orangeRed ]
                testEqual
                    "Child with pseudo" 
                    actual
-                   $".{className} > all:hover {{ background-color: aqua; }}"
+                   $".{className} > *:hover {{ background-color: aqua; }}"
                let className, actual = createSelector [ Color.red; !  Fss.Types.Html.All [ Hover [ BackgroundColor.aqua ] ]; BackgroundColor.orangeRed ]
                testEqual
                    "Descendant with pseudo" 
                    actual
-                   $".{className} all:hover {{ background-color: aqua; }}"
+                   $".{className} *:hover {{ background-color: aqua; }}"
                let className, actual =
                    createSelector [ ! Fss.Types.Html.All [ !> Fss.Types.Html.All [ !+ Fss.Types.Html.All [ !~ Fss.Types.Html.A [ Visited [ Color.white ] ] ] ] ] ]
                testEqual
                    "Descendant with nested selectors" 
                    actual
-                   $".{className} all > all + all ~ a:visited {{ color: white; }}"
+                   $".{className} * > * + * ~ a:visited {{ color: white; }}"
                    
                let className, actual =
                   createFss [ !+ Fss.Types.Html.All [ BorderColor.green
@@ -103,6 +103,6 @@ module SelectorTests =
               testEqual
                   "adjacent sibling with nested selectors"
                   actual
-                  $""".{className} + all {{ border-color: green; }}.{className} + all:hover {{ border-color: red; }}@media (max-height: 2em) {{ .{className} + all {{ content: "Query in pseudo"; }} }}"""
+                  $""".{className} + * {{ border-color: green; }}.{className} + *:hover {{ border-color: red; }}@media (max-height: 2em) {{ .{className} + * {{ content: "Query in pseudo"; }} }}"""
               
            ]


### PR DESCRIPTION
Corrects an issue where `Fss.Types.Html.All` is generated as `all` instead of `*`.