### PR TITLE
Adds Falco.Markup support and NuGet package

### DIFF
--- a/Documentation/Documentation.fs
+++ b/Documentation/Documentation.fs
@@ -92,6 +92,9 @@ let feliz: JS.Promise<unit -> ReactElement> =
 let giraffe: JS.Promise<unit -> ReactElement> =
     JsInterop.importDynamic "./Pages/Giraffe.fs"
 
+let falco: JS.Promise<unit -> ReactElement> =
+    JsInterop.importDynamic "./Pages/Falco.fs"
+
 let troubleshoot: JS.Promise<unit -> ReactElement> =
     JsInterop.importDynamic "./Pages/Troubleshoot.fs"
 
@@ -303,6 +306,7 @@ let Main (page: Page) =
                 | Fable -> Suspense fable
                 | Feliz -> Suspense feliz
                 | Giraffe -> Suspense giraffe
+                | Falco -> Suspense falco
             | OtherPage page ->
                 match page with
                 | Troubleshoot -> Suspense troubleshoot

--- a/Documentation/Documentation.fsproj
+++ b/Documentation/Documentation.fsproj
@@ -38,6 +38,7 @@
     <Compile Include="Pages\Fable.fs" />
     <Compile Include="Pages\Feliz.fs" />
     <Compile Include="Pages\Giraffe.fs" />
+    <Compile Include="Pages\Falco.fs" />
     <Compile Include="Pages\Troubleshoot.fs" />
     <Compile Include="Pages\Changelog.fs" />
     <Compile Include="Documentation.fs" />

--- a/Documentation/Pages.fs
+++ b/Documentation/Pages.fs
@@ -26,6 +26,7 @@ type LibraryPage =
     | Fable
     | Feliz
     | Giraffe
+    | Falco
     | Unknown
 
 type OtherPage =
@@ -66,6 +67,7 @@ let allLibraryPages =
       Fable
       Feliz
       Giraffe
+      Falco
     ] |> List.map LibraryPage
 
 let allOtherPages =
@@ -108,6 +110,7 @@ let stringToLibraryPage =
     | "fable" -> Some Fable
     | "feliz" -> Some Feliz
     | "giraffe" -> Some Giraffe
+    | "falco" -> Some Falco
     | _ -> None
 
 let stringToOtherPage =
@@ -151,6 +154,7 @@ let libraryPageToString =
     | Fable -> "Fable"
     | Feliz -> "Feliz"
     | Giraffe -> "Giraffe"
+    | Falco -> "Falco"
     | _ -> "Unknown"
 
 let otherPageToString =

--- a/Documentation/Pages/Falco.fs
+++ b/Documentation/Pages/Falco.fs
@@ -1,0 +1,10 @@
+module Page.Falco
+
+open Fss
+open Feliz
+open Fable.Core
+
+[<ReactComponent>]
+let Falco () = Page (Pages.LibraryPage Pages.Falco) []
+
+JsInterop.exportDefault Falco

--- a/FSharpCss.sln
+++ b/FSharpCss.sln
@@ -15,6 +15,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Documentation", "Documentat
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fss.Giraffe", "Fss.Giraffe\Fss.Giraffe.fsproj", "{15CF857B-7F1E-49C1-9D54-F4C541D50611}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fss.Falco", "Fss.Falco\Fss.Falco.fsproj", "{7E7B5612-7707-4190-8D4F-85806DE1C6AB}"
+EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Benchmark", "Benchmark\Benchmark.fsproj", "{A35C4755-EDD4-4A35-AE91-AD3907E39A71}"
 EndProject
 Global
@@ -114,5 +116,17 @@ Global
 		{A35C4755-EDD4-4A35-AE91-AD3907E39A71}.Release|x64.Build.0 = Release|Any CPU
 		{A35C4755-EDD4-4A35-AE91-AD3907E39A71}.Release|x86.ActiveCfg = Release|Any CPU
 		{A35C4755-EDD4-4A35-AE91-AD3907E39A71}.Release|x86.Build.0 = Release|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Debug|x64.Build.0 = Debug|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Debug|x86.Build.0 = Debug|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Release|x64.ActiveCfg = Release|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Release|x64.Build.0 = Release|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Release|x86.ActiveCfg = Release|Any CPU
+		{7E7B5612-7707-4190-8D4F-85806DE1C6AB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Fss.Falco/Fss.Falco.fsproj
+++ b/Fss.Falco/Fss.Falco.fsproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Provides helper functions for using Fss with Falco View Engine.</Description>
+        <RepositoryUrl>https://github.com/Bjorn-Strom/Fss.git</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/Bjorn-Strom/Fss</PackageProjectUrl>
+        <PackageTags>fsharp;fss;fss.core;CSS;styling;css-in-lang;Falco;viewengine;html</PackageTags>
+        <Authors>Bjørn-Ivar Strøm</Authors>
+        <Version>2.0.0</Version>
+        <PackageLicenseUrl>https://github.com/Bjorn-Strom/Fss/blob/master/LICENSE.md</PackageLicenseUrl>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <OutputType>Library</OutputType>
+        <PackageReleaseNotes>Rewrites Css generation and adds Attribute selectors.</PackageReleaseNotes>
+        <RootNamespace>Fss.Fable</RootNamespace>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageId>Fss-lib.Falco</PackageId>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="FssFalco.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Falco.Markup" Version="1.0.*" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Fss.Core\Fss.Core.fsproj" />
+    </ItemGroup>
+</Project>

--- a/Fss.Falco/FssFalco.fs
+++ b/Fss.Falco/FssFalco.fs
@@ -1,0 +1,60 @@
+﻿namespace Fss
+
+open Fss
+open System.Collections.Generic;
+open Falco.Markup
+
+[<AutoOpen>]
+module Falco =
+    let styleCache = Dictionary<string, XmlNode>()
+    let private createStyleNode className (css: string) =
+        if styleCache.ContainsKey className then
+            styleCache[className]
+        else
+            let newNode = Elem.style [ Attr.type' "text/css" ] [ Text.raw css ]
+            styleCache.Add (className, newNode)
+            newNode
+
+    /// Creates Css node and returns the classname and xml node
+    let fss (properties: Fss.Types.Rule list): string * XmlNode =
+        let className, cssRules = createFss properties
+
+        className, createStyleNode className cssRules
+
+    // Creates Css node as global styles. Returns xml ndoe
+    let global'(properties: Fss.Types.Rule list): XmlNode =
+        let cssRules = createGlobal properties
+        createStyleNode "*" cssRules
+
+    let private processCounterRules (rules: string) =
+        $"@counter-style {rules}"
+
+    /// Creates counter style node and returns the counter name and xml node
+    let counterStyle (properties: Fss.Types.CounterRule list): string * XmlNode =
+        let counterName, counterStyle =
+            properties
+            |> createCounterStyle
+
+        counterName, createStyleNode counterName <| processCounterRules counterStyle
+
+    let private processFontFaceRules (rules: string) =
+        $"@font-face {rules}"
+
+    /// Creates font face node and returns the font name and xml node
+    let fontFaces name (properties: Fss.Types.FontFaceRule list list): string * XmlNode =
+        let fontName, fontStyles =
+            properties
+            |> createFontFaces name
+
+        fontName, createStyleNode fontName <| processFontFaceRules fontStyles
+
+    let private processAnimationRules (rules: string) =
+        $"@keyframes {rules}"
+
+    /// Creates keyframes node and returns the counter name
+    let keyframes (properties: Keyframes list): string * XmlNode =
+        let animationName, animationStyles =
+            properties
+            |> createAnimation
+
+        animationName, createStyleNode animationName <| processAnimationRules animationStyles

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can also check out this sample repo: [samples](https://github.com/Bjorn-Stro
 ## Installation 💾
 
 Install the Nuget package you need. If you are using Fable or Feliz then you probably want `Fss.Fable` or `Fss.Feliz`.
-If you are using Giraffe then you probably want `Fss.Giraffe`. Doing something custom or extending Fss? Then you
+If you are using Giraffe then you probably want `Fss.Giraffe`, and if you are using `Falco` then you probably want `Fss.Falco`. Doing something custom or extending Fss? Then you
 probably want `Fss.Core`.
 
 | Package                                                        | NuGet                                                                                   | Downloads                                                                                |
@@ -50,6 +50,7 @@ probably want `Fss.Core`.
 | [Fss.Fable](https://www.nuget.org/packages/Fss-lib.Fable/)     | ![Nuget](https://img.shields.io/nuget/v/fss-lib.fable?style=for-the-badge&logo=nuget)   | ![Nuget](https://img.shields.io/nuget/dt/fss-lib.fable?style=for-the-badge&logo=nuget)   |
 | [Fss.Feliz](https://www.nuget.org/packages/Fss-lib-feliz/)     | ![Nuget](https://img.shields.io/nuget/v/fss-lib.feliz?style=for-the-badge&logo=nuget)   | ![Nuget](https://img.shields.io/nuget/dt/fss-lib.feliz?style=for-the-badge&logo=nuget)   |
 | [Fss.Giraffe](https://www.nuget.org/packages/Fss-lib.Giraffe/) | ![Nuget](https://img.shields.io/nuget/v/fss-lib.giraffe?style=for-the-badge&logo=nuget) | ![Nuget](https://img.shields.io/nuget/dt/fss-lib.giraffe?style=for-the-badge&logo=nuget) |
+| [Fss.Falco](https://www.nuget.org/packages/Fss-lib.Falco/) | ![Nuget](https://img.shields.io/nuget/v/fss-lib.falco?style=for-the-badge&logo=nuget) | ![Nuget](https://img.shields.io/nuget/dt/fss-lib.falco?style=for-the-badge&logo=nuget) |
 
 To install `Fss` you need to install the nuget package.
 

--- a/public/documentation/Falco.md
+++ b/public/documentation/Falco.md
@@ -1,0 +1,66 @@
+## Fss.Falco
+
+## Installation
+
+```
+# nuget
+dotnet add package Fss-lib.Falco
+```
+
+## Usage
+
+This library provides helper functions to make it easier to use Fss with [Falco Markup](https://github.com/pimbrouwers/Falco.Markup).
+
+The biggest difference when using Fss with Falco is that there is no automatic injection of styles into the dom.
+That is because there is no reliable way of doing that with the view engine.
+
+`Fss.Falco` provides these functions:
+
+- `fss: Rule list -> string * XmlNode`
+    - This is the function you want to use most of the time. Supply it
+      with the CSS rules you want and it will create the CSS for you and return the classname and a style node.
+      place this style node in the children list of `head` and then use the classname in your html element of choice.
+
+- `global': Rule list -> XmlNode`
+    - Takes a list of rules and creates a style node you can insert in your dom to get global styling.
+
+- `counterStyle: CounterRule list -> string * XmlNode`
+    - Takes a list of counter rules, creates a counter and returns a counter name and style node.
+      place this style node in the children list of `head` and then use the counter name in your html element of choice.
+
+- `fontFace': FontFaceRule list -> string * XmlNode`
+    - Takes a list of font face rules, creates a fontface and returns its name and style node.
+      place this style node in the children list of `head` and then use the font face name in your html element of choice.
+
+- `fontFaces': FontFaceRule list list -> string * XmlNode`
+  - Takes a list with lists of font face rules, creates a fontface and returns its name and style node.
+    place this style node in the children list of `head` and then use the font face name in your html element of choice.
+
+- `keyframes': Keyframes list -> string`
+    - Takes a list of keyframes rules, creates a keyframe, inserts it into the dom and returns the font name.
+      This font name can then be used when creating other rules.
+
+## Examples
+Using `Fss.Falco` is as simple as:
+
+
+```fsharp
+let hoverClassName, hoverStyleNode =
+    fss [
+        Width.value (px 200)
+        Height.value (px 200)
+        BackgroundColor.green
+        Hover [
+            BackgroundColor.red
+        ]
+    ]
+
+Elem.head []
+    [
+        hoverStyleNode
+    ]
+Elem.body []
+    [
+        Elem.div [ Attr.class' hoverClassName ] []
+    ]
+```

--- a/public/documentation/Installation.md
+++ b/public/documentation/Installation.md
@@ -5,6 +5,7 @@ Fss provides several libraries you can choose from:
 - [Fss.Fable](https://www.nuget.org/packages/Fss-lib.Fable/) is built on Fss.Core and Fable to give some convenience functions when using Fss with Fable.React.
 - [Fss.Feliz](https://www.nuget.org/packages/Fss-lib.Feliz/) lets you write Fss with Feliz syntax. This is built on Fss.Fable.
 - [Fss.Giraffe](https://www.nuget.org/packages/Fss-lib.Giraffe/)  provides helper functions that makes it easier to work with [GiraffeViewEngine](https://github.com/giraffe-fsharp/Giraffe.ViewEngine). Built atop `Fss.Core`
+- [Fss.Falco](https://www.nuget.org/packages/Fss-lib.Falco/)  provides helper functions that makes it easier to work with [Falco Markup](https://github.com/pimbrouwers/Falco.Markup). Built atop `Fss.Core`
 
 Just install the nuget package you need and you are good to go.
 

--- a/public/documentation/Overview.md
+++ b/public/documentation/Overview.md
@@ -12,7 +12,8 @@ In other words, it works both with Fable and Dotnet.
 In addition to [Fss.Core](https://www.nuget.org/packages/Fss-lib.Core/) there exists framework specific libraries which aim to make using
 Fss more ergonomic. Currently there exists libraries for:
 - [Fable](https://fable.io/)
-- [Feliz](https://zaid-ajaj.github.io/Feliz/) 
+- [Feliz](https://zaid-ajaj.github.io/Feliz/)
 - [Giraffe](https://github.com/giraffe-fsharp/Giraffe)
+- - [Giraffe](https://github.com/pimbrouwers/Falco)
 
 Check out the framework library documentation pages for specifics on how they work.


### PR DESCRIPTION
Hi there!

I recently decoupled the markup module within Falco into it's own [NuGet package](https://github.com/pimbrouwers/Falco.Markup). And I'd love to extend your fleet of libs to include it!

I feel like I have touched all the places that need addressing to make this happen. A couple points:
1. I used an initial version of 2.0.0 to keep in line with the others. 
2. I was confused by this in the docs: "...there is no automatic injection of styles into the dom". I included it in the Falco docs anyway, but I just wasn't sure what you meant by it.
3. I set the package version to track a rolling patch version `1.0.*`.

Thanks for your work on this!