### PR TITLE
Feature: Border shorthand

### DIFF
--- a/Fss.Core/Types/Border.fs
+++ b/Fss.Core/Types/Border.fs
@@ -74,20 +74,22 @@ module Border =
                     match this.Width with
                     | Some width ->
                         match width with
-                        | :? Width as width -> $"{(width :> ICssValue).StringifyCss()} "
-                        | :? ILengthPercentage as il -> $"{lengthPercentageString il} "
+                        | :? Width as width -> $"{(width :> ICssValue).StringifyCss()}"
+                        | :? ILengthPercentage as il -> $"{lengthPercentageString il}"
                         | _ -> "Error getting border width shorthand"
                     | None -> ""
+
                 let styleString =
                     match this.Style with
                     | Some style -> $"{(style :> ICssValue).StringifyCss()}"
                     | None -> ""
+
                 let colorString =
                     match this.Color with
-                    | Some color -> $" {(color :> ICssValue).StringifyCss()}"
+                    | Some color -> $"{(color :> ICssValue).StringifyCss()}"
                     | None -> ""
 
-                $"{widthString}{styleString}{colorString}"
+                $"{widthString} {styleString} {colorString}".Replace("  ", " ").Trim()
 
 
 [<RequireQualifiedAccess>]
@@ -292,13 +294,11 @@ module BorderClasses =
         member this.value(border: None') = (property, border) |> Rule
         // Shorthand test
         // Defines the shorthand function.
-        // Another shorthand could be border: width color or border: style color. or any permutation of these 3.
-        // Would one function with optional parameters be better?
-        member this.value(width: ILengthPercentage, style: Border.Style, color: Color) =
+        member this.value(?width: ILengthPercentage, ?style: Border.Style, ?color: Color) =
             let shorthand: Border.Shorthand = {
-                Color = Some color
-                Style = Some style
-                Width = Some width
+                Color = color
+                Style = style
+                Width = width
             }
             (property, shorthand) |> Rule
         member this.none = (property, None') |> Rule

--- a/Fss.Core/Types/Border.fs
+++ b/Fss.Core/Types/Border.fs
@@ -74,19 +74,20 @@ module Border =
                     match this.Width with
                     | Some width ->
                         match width with
-                        | :? Width as width -> $"{(width :> ICssValue).StringifyCss()}"
-                        | :? ILengthPercentage as il -> $"{lengthPercentageString il}"
+                        | :? Width as width -> (width :> ICssValue).StringifyCss()
+                        | :? Percent as p -> stringifyICssValue p
+                        | :? Length as l -> stringifyICssValue l
                         | _ -> "Error getting border width shorthand"
                     | None -> ""
 
                 let styleString =
                     match this.Style with
-                    | Some style -> $"{(style :> ICssValue).StringifyCss()}"
+                    | Some style -> (style :> ICssValue).StringifyCss()
                     | None -> ""
 
                 let colorString =
                     match this.Color with
-                    | Some color -> $"{(color :> ICssValue).StringifyCss()}"
+                    | Some color -> (color :> ICssValue).StringifyCss()
                     | None -> ""
 
                 $"{widthString} {styleString} {colorString}".Replace("  ", " ").Trim()
@@ -292,8 +293,7 @@ module BorderClasses =
     type Border(property) =
         inherit CssRule(property)
         member this.value(border: None') = (property, border) |> Rule
-        // Shorthand test
-        // Defines the shorthand function.
+
         member this.value(?width: ILengthPercentage, ?style: Border.Style, ?color: Color) =
             let shorthand: Border.Shorthand = {
                 Color = color

--- a/tests/Border.fs
+++ b/tests/Border.fs
@@ -25,9 +25,35 @@ module BorderTests =
                     [ Border.value(px 1, Fss.Types.Border.Style.Solid, hex "#fff") ]
                     "{border:1px solid #fff;}"
 
+                testCase
+                    "Border shorthand partial"
+                    [ Border.value(width = Fss.Types.Border.Width.Thin) ]
+                    "{border:thin;}"
 
+                testCase
+                    "Border shorthand partial 2"
+                    [ Border.value(style = Fss.Types.Border.Style.Dotted) ]
+                    "{border:dotted;}"
 
+                testCase
+                    "Border shorthand partial 3"
+                    [ Border.value(color = Fss.Types.Color.Aqua) ]
+                    "{border:aqua;}"
 
+                testCase
+                    "Border shorthand partial 4"
+                    [ Border.value(width = Fss.Types.Border.Width.Thin, style = Fss.Types.Border.Style.Dotted) ]
+                    "{border:thin dotted;}"
+
+                testCase
+                    "Border shorthand partial 5"
+                    [ Border.value(width = Fss.Types.Border.Width.Thin, color = Fss.Types.Color.Aqua) ]
+                    "{border:thin aqua;}"
+
+                testCase
+                    "Border shorthand partial 6"
+                    [ Border.value(style = Fss.Types.Border.Style.Dotted, color = Fss.Types.Color.Aqua) ]
+                    "{border:dotted aqua;}"
 
                 // Old tests
                 testCase

--- a/tests/Border.fs
+++ b/tests/Border.fs
@@ -1,7 +1,6 @@
 ﻿namespace FSSTests
 
 open Fet
-open Fss.Types
 open Utils
 open Fss
 
@@ -9,53 +8,43 @@ module BorderTests =
      let tests =
         testList "Border"
             [
-                // Shorthand test
-                // I should add a way to focus tests with the testing library
-
-                // This is the most basic way I could make the border shorthand somewhat work
-                // The issue is that it references the border types directly which
-                // Is annoying having to type.
                 testCase
-                    "Border shorthand"
+                    "Border shorthand: all values"
                     [ Border.value(Fss.Types.Border.Width.Medium, Fss.Types.Border.Style.Dashed, Fss.Types.Color.Green) ]
                     "{border:medium dashed green;}"
-
                 testCase
-                    "Border shorthand 2"
+                    "Border shorthand: all values, with pixel width"
                     [ Border.value(px 1, Fss.Types.Border.Style.Solid, hex "#fff") ]
                     "{border:1px solid #fff;}"
-
                 testCase
-                    "Border shorthand partial"
+                    "Border shorthand: only width"
                     [ Border.value(width = Fss.Types.Border.Width.Thin) ]
                     "{border:thin;}"
-
                 testCase
-                    "Border shorthand partial 2"
+                    "Border shorthand: only width with percent"
+                    [ Border.value(width = pct 10) ]
+                    "{border:10%;}"
+                testCase
+                    "Border shorthand: only style"
                     [ Border.value(style = Fss.Types.Border.Style.Dotted) ]
                     "{border:dotted;}"
-
                 testCase
-                    "Border shorthand partial 3"
+                    "Border shorthand: only color"
                     [ Border.value(color = Fss.Types.Color.Aqua) ]
                     "{border:aqua;}"
-
                 testCase
-                    "Border shorthand partial 4"
+                    "Border shorthand: width and style"
                     [ Border.value(width = Fss.Types.Border.Width.Thin, style = Fss.Types.Border.Style.Dotted) ]
                     "{border:thin dotted;}"
-
                 testCase
-                    "Border shorthand partial 5"
+                    "Border shorthand: width and color"
                     [ Border.value(width = Fss.Types.Border.Width.Thin, color = Fss.Types.Color.Aqua) ]
                     "{border:thin aqua;}"
-
                 testCase
-                    "Border shorthand partial 6"
+                    "Border shorthand: style and color"
                     [ Border.value(style = Fss.Types.Border.Style.Dotted, color = Fss.Types.Color.Aqua) ]
                     "{border:dotted aqua;}"
 
-                // Old tests
                 testCase
                     "Border initial"
                     [ Border.initial ]


### PR DESCRIPTION
I've made the change to optional parameters for the border shorthand. Is there anything else missing?