### PR TITLE
'Zero' length unit

### DIFF
--- a/Fss.Core/Functions.fs
+++ b/Fss.Core/Functions.fs
@@ -424,6 +424,9 @@ module Functions =
     // Auto
     let auto = Auto
 
+    // Zero
+    let zero = Zero
+
     // Time 
     let sec (v: float) : Time = Sec v
     let ms (v: float) : Time = Ms v

--- a/Fss.Core/Types/MasterTypes.fs
+++ b/Fss.Core/Types/MasterTypes.fs
@@ -22,6 +22,10 @@ type ILengthUnit =
     interface
     end
     
+type ILengthPercentage =
+    interface
+    end
+
 type Selector =
     | Tag of Html.Html
     | Id of string

--- a/Fss.Core/Types/Properties.fs
+++ b/Fss.Core/Types/Properties.fs
@@ -904,6 +904,7 @@ type Auto =
         member this.StringifyCounter() = stringifyICssValue this
         
     interface ILengthUnit
+    interface ILengthPercentage
 
     interface ICssValue with
         member this.StringifyCss() = "auto"

--- a/Fss.Core/Types/Units.fs
+++ b/Fss.Core/Types/Units.fs
@@ -50,6 +50,13 @@ type Length =
             | VMax v -> $"{string v}vmax"
             | VMin v -> $"{string v}vmin"
 
+type Zero =
+    | Zero
+    interface ILengthUnit
+    interface ILengthPercentage
+
+    interface ICssValue with
+        member this.StringifyCss() = "0"
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/angle
 type Angle =
@@ -95,6 +102,7 @@ module unitHelpers =
         | :? Percent as p -> p :> ICssValue
         | :? Length as l -> l :> ICssValue
         | :? Auto as a -> a :> ICssValue
+        | :? Zero as z -> z :> ICssValue
         | _ -> Px 0
 
     let internal lengthPercentageString (lp: ILengthPercentage) =
@@ -102,6 +110,7 @@ module unitHelpers =
         | :? Percent as p -> stringifyICssValue p
         | :? Length as l -> stringifyICssValue l
         | :? Auto as a -> stringifyICssValue a
+        | :? Zero as z -> stringifyICssValue z
         | _ -> ""
 
     let internal ILengthUnitToType (lu: ILengthUnit) =
@@ -109,6 +118,7 @@ module unitHelpers =
         | :? Percent as p -> p :> ICssValue
         | :? Length as l -> l :> ICssValue
         | :? Auto as a -> a :> ICssValue
+        | :? Zero as z -> z :> ICssValue
         | _ -> Px 0
 
     let internal ILengthUnitToString (lu: ILengthUnit) =
@@ -116,6 +126,7 @@ module unitHelpers =
         | :? Percent as p -> stringifyICssValue p
         | :? Length as l -> stringifyICssValue l
         | :? Auto as a -> stringifyICssValue a
+        | :? Zero as z -> stringifyICssValue z
         | _ -> ""
 
     type CssRuleWithLength(property) =

--- a/Fss.Core/Types/Units.fs
+++ b/Fss.Core/Types/Units.fs
@@ -1,10 +1,6 @@
 namespace Fss
 namespace Fss.Types
 
-type ILengthPercentage =
-    interface
-    end
-
 type Percent =
     | Percent of int
     interface ILengthUnit
@@ -98,12 +94,14 @@ module unitHelpers =
         match lp with
         | :? Percent as p -> p :> ICssValue
         | :? Length as l -> l :> ICssValue
+        | :? Auto as a -> a :> ICssValue
         | _ -> Px 0
 
     let internal lengthPercentageString (lp: ILengthPercentage) =
         match lp with
         | :? Percent as p -> stringifyICssValue p
         | :? Length as l -> stringifyICssValue l
+        | :? Auto as a -> stringifyICssValue a
         | _ -> ""
 
     let internal ILengthUnitToType (lu: ILengthUnit) =

--- a/tests/Margin.fs
+++ b/tests/Margin.fs
@@ -121,6 +121,10 @@ module MarginTests =
                     [ Margin.auto]
                     "{margin:auto;}"
                 testCase
+                    "Margin auto (value)"
+                    [ Margin.value (auto) ]
+                    "{margin:auto;}"
+                testCase
                     "Margin inherit"
                     [ Margin.inherit']
                     "{margin:inherit;}"

--- a/tests/Margin.fs
+++ b/tests/Margin.fs
@@ -117,6 +117,10 @@ module MarginTests =
                     [ Margin.value (em 10.0)]
                     "{margin:10em;}"
                 testCase
+                    "Margin zero"
+                    [ Margin.value (zero)]
+                    "{margin:0;}"
+                testCase
                     "Margin auto"
                     [ Margin.auto]
                     "{margin:auto;}"
@@ -124,6 +128,10 @@ module MarginTests =
                     "Margin auto (value)"
                     [ Margin.value (auto) ]
                     "{margin:auto;}"
+                testCase
+                    "Margin zero auto"
+                    [ Margin.value (zero, auto)]
+                    "{margin:0 auto;}"
                 testCase
                     "Margin inherit"
                     [ Margin.inherit']


### PR DESCRIPTION
Sorry for the late delivery, I was busy this week.

Here is a PR about the issue #27, moving ILengthPercentage, allowing Auto to be used as value and creating a new length, called Zero, for when we need empty values.

At the moment, I've tested the values only in Margin.